### PR TITLE
Verify documentation matches code

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ public partial record NewCatVersion2(string Name, bool LikesCatnip) : Animal(Nam
 
 ### 2. Register the polymorphic mappers
 
-The source generator creates a registration extension method in your project's namespace:
+The source generator creates a registration extension method in your project's namespace. The generated class follows the pattern `{AssemblyName}Serialization`:
 
 ```csharp
 using System.Text.Json;
@@ -103,7 +103,8 @@ using Hexalith.PolymorphicSerializations;
 
 // Register all polymorphic mappers defined in your project
 // This connects your model classes to the serialization system
-MyProject.RegisterPolymorphicMappers();
+// The generated class name follows the pattern: {AssemblyName}Serialization
+MyProjectSerialization.RegisterPolymorphicMappers();
 
 // Serialize the Car object. You need to specify polymorphic deserialization by using the Polymorphic type.
 string json = JsonSerializer.Serialize<Polymorphic>(new Car("Volvo", "Electric"), PolymorphicHelper.DefaultJsonSerializerOptions);
@@ -116,7 +117,7 @@ var value = JsonSerializer.Deserialize<Polymorphic>(json, PolymorphicHelper.Defa
 
 For more detailed usage examples and demonstrations of various features, explore the sample applications:
 
-- **[Sample Application README](./samples/README.md)**
+- **[Examples README](./examples/README.md)**
   - Includes examples like deserializing polymorphic messages from files (`DeserializeFileMessages`).
 
 ## Repository Structure

--- a/examples/DeserializeFileMessages/README.md
+++ b/examples/DeserializeFileMessages/README.md
@@ -112,7 +112,7 @@ The serialized JSON will include type discriminators (`$type` property) to prese
 ```json
 [
   {
-    "$type": "Hello",
+    "$type": "SayHello",
     "To": "World"
   },
   {
@@ -127,6 +127,8 @@ The serialized JSON will include type discriminators (`$type` property) to prese
 ]
 ```
 
+Note: The `$type` discriminator is derived from the class name when no custom name is specified in the `[PolymorphicSerialization]` attribute. For versioned types (version > 1), the format is `{Name}V{Version}` (e.g., "ByeV2" for `name: "Bye", version: 2`).
+
 ## Dependencies
 
 This sample references:
@@ -136,5 +138,5 @@ This sample references:
 ## Learn More
 
 For more information about the libraries used in this sample, refer to:
-- [Hexalith.PolymorphicSerializations Documentation](../../src/Hexalith.PolymorphicSerializations/README.md)
-- [Hexalith.PolymorphicSerializations.CodeGenerators Documentation](../../src/Hexalith.PolymorphicSerializations.CodeGenerators/README.md)
+- [Main Project README](../../README.md)
+- [Examples Overview](../README.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,11 +8,11 @@ This directory contains sample applications demonstrating how to use the Hexalit
 
 A sample application demonstrating how to deserialize polymorphic messages from files. This sample shows:
 
-- Configuration of polymorphic serialization
-- Reading and deserializing different message types from JSON files
-- Type discrimination using various strategies
-- Error handling during deserialization
-- Best practices for polymorphic type resolution
+- Defining polymorphic message types using C# records
+- Applying the `[PolymorphicSerialization]` attribute for type discrimination
+- Serializing heterogeneous lists to JSON files
+- Deserializing JSON back to strongly-typed objects
+- Using source-generated serialization mappers
 
 [Browse the DeserializeFileMessages sample](./DeserializeFileMessages)
 
@@ -24,10 +24,10 @@ Each sample can be run independently. Navigate to the sample directory and follo
 
 All samples demonstrate these common patterns for working with Hexalith.PolymorphicSerializations:
 
-1. **Type Registration**: How to register polymorphic types for serialization/deserialization
-2. **Type Discrimination**: Techniques for discriminating between different types during deserialization
-3. **Custom Converters**: Implementation of custom converters for special serialization needs
-4. **Configuration Options**: Different configuration options for serialization behaviors
+1. **Type Registration**: How to register polymorphic types using source-generated mappers
+2. **Type Discrimination**: Using the `$type` discriminator property for polymorphic deserialization
+3. **Inheritance Hierarchies**: Working with abstract base classes and concrete derived types
+4. **Versioning**: Using version numbers in type discriminators (e.g., "TypeV2")
 
 ## Contributing New Samples
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,1 +1,27 @@
+# Source Code
 
+This directory contains the source code for the Hexalith.PolymorphicSerializations packages.
+
+## Libraries
+
+### Hexalith.PolymorphicSerializations
+
+The core library providing polymorphic serialization support for System.Text.Json. Key components include:
+
+- **PolymorphicSerializationAttribute**: Attribute to mark types for polymorphic serialization
+- **Polymorphic**: Base record class that all polymorphic types inherit from
+- **PolymorphicHelper**: Helper methods and default serializer options
+- **PolymorphicSerializationResolver**: Custom JSON type resolver for polymorphic types
+- **PolymorphicSerializationMapper**: Generic mapper for type discrimination
+
+### Hexalith.PolymorphicSerializations.CodeGenerators
+
+Source generator package that automatically generates serialization mappers at compile time. Features:
+
+- Automatic mapper class generation for types decorated with `[PolymorphicSerialization]`
+- Generation of registration extension methods for dependency injection
+- Static registration method for non-DI scenarios
+
+## Building
+
+The projects in this directory are built as part of the main solution. See the [main README](../README.md) for build instructions.


### PR DESCRIPTION
- Fix broken link in README.md (samples -> examples)
- Correct generated class naming pattern in Quick Start example (MyProjectSerialization instead of MyProject)
- Fix incorrect type discriminator in DeserializeFileMessages example ("SayHello" not "Hello")
- Fix broken documentation links in DeserializeFileMessages README
- Add meaningful content to empty src/README.md
- Update examples/README.md with accurate feature descriptions